### PR TITLE
fixes for Nextcloud 19 

### DIFF
--- a/lib/LDAP/EntityFactory.php
+++ b/lib/LDAP/EntityFactory.php
@@ -239,7 +239,7 @@ class EntityFactory {
 
     // get all users from all servers
     foreach ($this->getAvailableServerList() as $server) {
-      $serverUserList = $server->fetchListOfUsers($server->connection->ldapUserFilter, 'dn');
+      $serverUserList = $server->fetchListOfUsers($server->connection->ldapUserFilter, ['dn']);
 
       // loop through all users
       foreach ($serverUserList as $dn) {
@@ -268,7 +268,7 @@ class EntityFactory {
 
     // get all groups from all servers
     foreach ($this->getAvailableServerList() as $server) {
-      $serverGroupList = $server->fetchListOfGroups($server->connection->ldapGroupFilter, 'dn');
+      $serverGroupList = $server->fetchListOfGroups($server->connection->ldapGroupFilter, ['dn']);
       // loop through all groups
       foreach ($serverGroupList as $dn) {
         try {

--- a/lib/LDAP/LdapGroup.php
+++ b/lib/LDAP/LdapGroup.php
@@ -19,7 +19,7 @@ class LdapGroup extends LdapEntity {
    */
   protected function loadLdapAttributeValues() {
     // fetch ladp attributes
-    $groupList = $this->server->search($this->server->connection->ldapGroupFilter, [$this->dn], $this->ldapAttributeKeys);
+    $groupList = $this->server->search($this->server->connection->ldapGroupFilter, $this->dn, $this->ldapAttributeKeys);
     if (empty($groupList)) return false;
     // turn the array values into single strings
     foreach ($groupList[0] as $attributeKey => $valueArray) {

--- a/lib/LDAP/LdapUser.php
+++ b/lib/LDAP/LdapUser.php
@@ -59,7 +59,7 @@ class LdapUser extends LdapEntity {
    */
   protected function loadLdapAttributeValues() {
     // fetch ladp attributes
-    $userList = $this->server->search($this->server->connection->ldapUserFilter, [$this->dn], $this->ldapAttributeKeys);
+    $userList = $this->server->search($this->server->connection->ldapUserFilter, $this->dn, $this->ldapAttributeKeys);
     if (empty($userList)) return false;
     // turn the array values into single strings
     foreach ($userList[0] as $attributeKey => $valueArray) {


### PR DESCRIPTION
When installing the LdapContacts plug-on on Nextcloud 19, accessing the LDAPContacts showed spinning wheels forever and the server log showed error 500 on:
GET /apps/ldapcontacts/groups
GET /apps/ldapcontacts/own
GET /apps/ldapcontacts/load

Nextcloud logging reveals:
```Argument 3 passed to OCA\User_LDAP\Access::search() must be of the type array or null, string given, called in /var/www/html/apps/user_ldap/lib/Access.php on line 1009```
and
```Argument 2 passed to OCA\User_LDAP\Access::search() must be of the type string, array given, called in /var/www/html/custom_apps/ldapcontacts/lib/LDAP/LdapUser.php on line 62```

See attached patch which fixes the access to (obviously recently implemented) changes in the user_ldap App.